### PR TITLE
CakePHP 3.6 Upgrade: Change extensions() to setExtensions() 

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -3,7 +3,7 @@
 
   # enable /sitemap and /sitemap.xml
   Router::scope('/', function($routes){
-    $routes->extensions(['xml']);
+    $routes->setExtensions(['xml']);
     $routes->connect('/sitemap', [
       'plugin' => 'Sitemap',
       'controller' => 'Sitemaps',


### PR DESCRIPTION
Make plugin compatible with CakePHP 3.6 by replacing deprecated method.